### PR TITLE
Default to 'text' for unknown extensions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -15833,11 +15833,14 @@ function getExt(file) {
 	return path.extname(file).slice(1)
 }
 
+function extensionType(extension) {
+  EXTENSIONS_TO_CHECK[extension] || 'text';
+}
 
 function checkFile(file, options) {
 	console.warn(`checking ${file}`)
 	const extension = getExt(file)
-	const checkType = EXTENSIONS_TO_CHECK[extension]
+	const checkType = extensionType(extension)
 
 	const body = fs.readFileSync(file, "utf-8");
 

--- a/utils.js
+++ b/utils.js
@@ -35,11 +35,14 @@ function getExt(file) {
 	return path.extname(file).slice(1)
 }
 
+function extensionType(extension) {
+  EXTENSIONS_TO_CHECK[extension] || 'text';
+}
 
 function checkFile(file, options) {
 	console.warn(`checking ${file}`)
 	const extension = getExt(file)
-	const checkType = EXTENSIONS_TO_CHECK[extension]
+	const checkType = extensionType(extension)
 
 	const body = fs.readFileSync(file, "utf-8");
 


### PR DESCRIPTION
If extensions are not part of the `EXTENSIONS_TO_CHECK` map the code now defaults to `'text'` as an extension. This fixes #2.